### PR TITLE
fix(docs): show kbd component in code preview

### DIFF
--- a/content/1.docs/2.essentials/3.prose-components.md
+++ b/content/1.docs/2.essentials/3.prose-components.md
@@ -372,7 +372,7 @@ Use `kbd` to display keyboard keys or shortcuts. `kbd` components clearly indica
 ---
 class: "[&>div]:*:my-0"
 ---
-`` ``
+:kbd{value="meta"} :kbd{value="K"}
 
 #code
 ```mdc


### PR DESCRIPTION
### Before

<img width="786" height="132" alt="chrome_rzuAQR6BKT" src="https://github.com/user-attachments/assets/556657db-df9d-4e06-bb50-9d911e7b1776" />

### After

<img width="786" height="132" alt="chrome_wzVrarP1wv" src="https://github.com/user-attachments/assets/3788fbc3-289d-49df-879b-c0e79d07fa26" />
