### PR TITLE
feat(auth): add polar sandbox subscriptions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,11 @@ NUXT_BETTER_AUTH_SECRET=
 # GitHub OAuth credentials consumed by sign-in provider setup
 NUXT_GITHUB_CLIENT_ID=
 NUXT_GITHUB_CLIENT_SECRET=
+
+# Polar Sandbox billing
+NUXT_POLAR_ACCESS_TOKEN=
+NUXT_POLAR_RETURN_URL=
+
+# Public product used by checkout and subscription state
+NUXT_PUBLIC_POLAR_PRODUCT_ID=
+NUXT_PUBLIC_POLAR_PRODUCT_SLUG=pro

--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ openssl rand -base64 32
 NUXT_BETTER_AUTH_SECRET=<your-generated-secret>
 ```
 
+### Polar Sandbox Billing
+
+This template supports subscription checkout and customer portal flows via [Polar](https://polar.sh) using the Better Auth plugin: [@polar-sh/better-auth](https://www.npmjs.com/package/@polar-sh/better-auth).
+
+```bash
+NUXT_POLAR_ACCESS_TOKEN=<polar-sandbox-access-token>
+NUXT_POLAR_RETURN_URL=<app-base-url>
+NUXT_PUBLIC_POLAR_PRODUCT_ID=<polar-sandbox-product-id>
+NUXT_PUBLIC_POLAR_PRODUCT_SLUG=pro
+```
+
 ## Development Server
 
 Start the development server on `http://localhost:3000`:

--- a/app/auth.config.ts
+++ b/app/auth.config.ts
@@ -1,3 +1,6 @@
 import { defineClientAuth } from '@nuxtjs/better-auth/config'
+import { polarClient } from '@polar-sh/better-auth/client'
 
-export default defineClientAuth({})
+export default defineClientAuth({
+  plugins: [polarClient()]
+})

--- a/app/composables/useBillingState.ts
+++ b/app/composables/useBillingState.ts
@@ -1,0 +1,67 @@
+import type { Ref } from 'vue'
+
+export function useBillingState(loggedIn: Ref<boolean>, productId: string, productSlug: string) {
+  const toast = useToast()
+  const checkout = useAuthClientAction(client => client.checkout)
+  const portal = useAuthClientAction(client => client.customer.portal)
+  const customerState = useAuthClientAction(client => client.customer.state)
+
+  watch(loggedIn, (value) => {
+    if (value) {
+      customerState.execute()
+      return
+    }
+
+    customerState.data.value = null
+    customerState.error.value = null
+    customerState.status.value = 'idle'
+  }, { immediate: true })
+
+  const isSubscribed = computed(() => customerState.data.value?.data?.activeSubscriptions
+    ?.some(subscription => subscription.productId === productId) ?? false)
+
+  const isSubscriptionResolving = computed(() => loggedIn.value && (
+    customerState.status.value === 'idle' || customerState.status.value === 'pending'
+  ))
+
+  function showError(title: string, error: { message?: string } | null) {
+    toast.add({ color: 'error', title, description: error?.message || 'Please try again.' })
+  }
+
+  async function onManageSubscription() {
+    await portal.execute()
+
+    if (portal.error.value) {
+      showError('Unable to open portal', portal.error.value)
+    }
+  }
+
+  async function onUpgradeToPro() {
+    if (customerState.status.value === 'error') {
+      await customerState.execute()
+
+      if (customerState.error.value) {
+        showError('Unable to load subscription', customerState.error.value)
+        return
+      }
+    }
+
+    if (isSubscribed.value) {
+      await onManageSubscription()
+      return
+    }
+
+    await checkout.execute({ slug: productSlug })
+
+    if (checkout.error.value) {
+      showError('Unable to start checkout', checkout.error.value)
+    }
+  }
+
+  return {
+    isSubscribed,
+    isSubscriptionResolving,
+    onManageSubscription,
+    onUpgradeToPro
+  }
+}

--- a/app/pages/app/index.vue
+++ b/app/pages/app/index.vue
@@ -2,7 +2,9 @@
 useSeoMeta({ title: 'Dashboard' })
 
 const route = useRoute()
-const { user, signOut } = useUserSession()
+const { productId, productSlug } = useRuntimeConfig().public.polar
+const { user, loggedIn, signOut } = useUserSession()
+const { isSubscribed, isSubscriptionResolving, onUpgradeToPro, onManageSubscription } = useBillingState(loggedIn, productId, productSlug)
 
 const dashboardItems = computed(() => [[{
   label: 'Overview',
@@ -20,7 +22,7 @@ const dashboardItems = computed(() => [[{
 }, {
   label: 'Billing',
   icon: 'i-lucide-credit-card',
-  disabled: true
+  to: '/pricing'
 }]])
 </script>
 
@@ -44,6 +46,54 @@ const dashboardItems = computed(() => [[{
             orientation="vertical"
             :items="dashboardItems"
           />
+
+          <USeparator class="my-4" />
+
+          <BetterAuthState>
+            <template #default>
+              <div class="space-y-2">
+                <template v-if="isSubscriptionResolving">
+                  <div class="h-10 rounded-md bg-elevated animate-pulse" />
+                  <div class="h-10 rounded-md bg-elevated animate-pulse" />
+                </template>
+
+                <template v-else>
+                  <UButton
+                    v-if="isSubscribed"
+                    label="Pro plan active"
+                    icon="i-lucide-badge-check"
+                    color="success"
+                    variant="soft"
+                    disabled
+                    block
+                  />
+                  <UButton
+                    v-else
+                    label="Upgrade to Pro"
+                    icon="i-lucide-sparkles"
+                    color="primary"
+                    block
+                    @click="onUpgradeToPro"
+                  />
+                  <UButton
+                    :label="isSubscribed ? 'Manage subscription' : 'Billing portal'"
+                    icon="i-lucide-receipt-text"
+                    color="neutral"
+                    variant="soft"
+                    block
+                    @click="onManageSubscription"
+                  />
+                </template>
+              </div>
+            </template>
+
+            <template #placeholder>
+              <div class="space-y-2">
+                <div class="h-10 rounded-md bg-elevated animate-pulse" />
+                <div class="h-10 rounded-md bg-elevated animate-pulse" />
+              </div>
+            </template>
+          </BetterAuthState>
 
           <USeparator class="my-4" />
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -27,13 +27,23 @@ export default defineNuxtConfig({
     githubClient: {
       id: '',
       secret: ''
+    },
+    polar: {
+      accessToken: '',
+      returnUrl: ''
+    },
+    public: {
+      polar: {
+        productId: '',
+        productSlug: 'pro'
+      }
     }
   },
 
   routeRules: {
     '/docs': { redirect: '/docs/getting-started', prerender: false },
-    '/login': { auth: { only: 'guest' } },
-    '/signup': { auth: { only: 'guest' } },
+    '/login': { auth: { only: 'guest' }, prerender: false },
+    '/signup': { auth: { only: 'guest' }, prerender: false },
     '/app': { auth: 'user', prerender: false },
     '/app/**': { auth: 'user', prerender: false }
   },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "@nuxt/ui": "^4.11.0",
     "@nuxthub/core": "^0.10.8",
     "@nuxtjs/better-auth": "^0.1.4",
+    "@polar-sh/better-auth": "^1.8.1",
+    "@polar-sh/sdk": "^0.47.1",
     "@standard-schema/spec": "^1.1.0",
     "@takumi-rs/core": "^1.8.7",
     "@vueuse/nuxt": "^14.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,12 @@ importers:
       '@nuxtjs/better-auth':
         specifier: ^0.1.4
         version: 0.1.4(4e525f0ed689821a55e44bbbd7c7188f)
+      '@polar-sh/better-auth':
+        specifier: ^1.8.1
+        version: 1.8.4(@polar-sh/sdk@0.47.1)(@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@stripe/stripe-js@7.9.0)(better-auth@1.7.1(12683ad1e68286b0e1a65ce8090d4cc3))(react@19.2.8)(zod@4.4.3)
+      '@polar-sh/sdk':
+        specifier: ^0.47.1
+        version: 0.47.1
       '@standard-schema/spec':
         specifier: ^1.1.0
         version: 1.1.0
@@ -2287,6 +2293,24 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@polar-sh/better-auth@1.8.4':
+    resolution: {integrity: sha512-BgWCcBQDRYwQn2NEYYzGSEfnrmBJHaDTvYBXGE2V3mmGPKspUDS8+p1LzbNY0Sw681LT8HB5w5Q81Ysc46CVSQ==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@polar-sh/sdk': ^0.47.0
+      better-auth: ^1.4.12
+      zod: ^3.25.0 || ^4.0.0
+
+  '@polar-sh/checkout@0.2.1':
+    resolution: {integrity: sha512-AEKKw3o4ykApECA4bU6a2YC0+aQKTFUasca4ZgCDIjG8AHlu3SjW3Taxh2nfeYAczhah0m0axVF9AV8VfdYzfw==}
+    peerDependencies:
+      '@stripe/react-stripe-js': ^3.6.0 || ^4.0.2
+      '@stripe/stripe-js': ^7.1.0
+      react: ^18 || ^19
+
+  '@polar-sh/sdk@0.47.1':
+    resolution: {integrity: sha512-fkz7wPLbqfuDmY9LxuXpE2uP2TAV6J0q/YN5hJ4UBxpjbkB0hKM6c4R35N89t83dfzMlG6EOlqOn+Rd1T6XrJQ==}
+
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
@@ -2986,8 +3010,22 @@ packages:
     resolution: {integrity: sha512-PfWPWN2n+/37doa8oh2/oUXk4OOsRYZsxc1W1sDXIGb/Pu5Yrb+f2eyYpgQMGITVX7HVgxhs9P18Rc6I97ym/g==}
     engines: {node: '>=22'}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@stripe/react-stripe-js@4.0.2':
+    resolution: {integrity: sha512-l2wau+8/LOlHl+Sz8wQ1oDuLJvyw51nQCsu6/ljT6smqzTszcMHifjAJoXlnMfcou3+jK/kQyVe04u/ufyTXgg==}
+    peerDependencies:
+      '@stripe/stripe-js': '>=1.44.1 <8.0.0'
+      react: '>=16.8.0 <20.0.0'
+      react-dom: '>=16.8.0 <20.0.0'
+
+  '@stripe/stripe-js@7.9.0':
+    resolution: {integrity: sha512-ggs5k+/0FUJcIgNY08aZTqpBTtbExkJMYMLSMwyucrhtWexVOEY1KJmhBsxf+E/Q15f5rbwBpj+t0t2AW2oCsQ==}
+    engines: {node: '>=12.16'}
 
   '@stylistic/eslint-plugin@5.10.0':
     resolution: {integrity: sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==}
@@ -4608,6 +4646,9 @@ packages:
     resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
     engines: {node: '>=12'}
 
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
+
   db0@0.3.4:
     resolution: {integrity: sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==}
     peerDependencies:
@@ -5267,6 +5308,9 @@ packages:
 
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
@@ -6128,6 +6172,10 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -6630,6 +6678,10 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   object-deep-merge@2.0.1:
     resolution: {integrity: sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==}
 
@@ -7110,6 +7162,9 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
@@ -7199,6 +7254,9 @@ packages:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
     peerDependencies:
       react: ^19.2.8
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
@@ -7620,6 +7678,9 @@ packages:
 
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -11093,6 +11154,29 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@polar-sh/better-auth@1.8.4(@polar-sh/sdk@0.47.1)(@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@stripe/stripe-js@7.9.0)(better-auth@1.7.1(12683ad1e68286b0e1a65ce8090d4cc3))(react@19.2.8)(zod@4.4.3)':
+    dependencies:
+      '@polar-sh/checkout': 0.2.1(@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@stripe/stripe-js@7.9.0)(react@19.2.8)
+      '@polar-sh/sdk': 0.47.1
+      better-auth: 1.7.1(12683ad1e68286b0e1a65ce8090d4cc3)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@stripe/react-stripe-js'
+      - '@stripe/stripe-js'
+      - react
+
+  '@polar-sh/checkout@0.2.1(@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@stripe/stripe-js@7.9.0)(react@19.2.8)':
+    dependencies:
+      '@stripe/react-stripe-js': 4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@stripe/stripe-js': 7.9.0
+      date-fns: 4.4.0
+      react: 19.2.8
+
+  '@polar-sh/sdk@0.47.1':
+    dependencies:
+      standardwebhooks: 1.0.0
+      zod: 4.4.3
+
   '@polka/url@1.0.0-next.29': {}
 
   '@poppinss/colors@4.1.6':
@@ -11627,7 +11711,18 @@ snapshots:
 
   '@sqlite.org/sqlite-wasm@3.53.0-build1': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
+
+  '@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@stripe/stripe-js': 7.9.0
+      prop-types: 15.8.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
+  '@stripe/stripe-js@7.9.0': {}
 
   '@stylistic/eslint-plugin@5.10.0(eslint@10.9.0(jiti@2.7.0)(supports-color@10.2.2))':
     dependencies:
@@ -13390,6 +13485,8 @@ snapshots:
       d3-array: 3.2.4
     optional: true
 
+  date-fns@4.4.0: {}
+
   db0@0.3.4(@electric-sql/pglite@0.4.3)(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.4.3)(@libsql/client@0.17.4)(@prisma/client@5.22.0(prisma@7.9.1(@types/react@19.2.18)(better-sqlite3@12.11.1)(magicast@0.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)))(@types/pg@8.23.1)(better-sqlite3@12.11.1)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.23.0)(postgres@3.4.7)(prisma@7.9.1(@types/react@19.2.18)(better-sqlite3@12.11.1)(magicast@0.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)))(mysql2@3.15.3):
     optionalDependencies:
       '@electric-sql/pglite': 0.4.3
@@ -14080,6 +14177,8 @@ snapshots:
     dependencies:
       fast-decode-uri-component: 1.0.1
     optional: true
+
+  fast-sha256@1.3.0: {}
 
   fast-string-truncated-width@3.0.3: {}
 
@@ -14995,6 +15094,10 @@ snapshots:
     optional: true
 
   longest-streak@3.1.0: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
 
   lru-cache@10.4.3: {}
 
@@ -15949,6 +16052,8 @@ snapshots:
       pathe: 2.0.3
       tinyexec: 1.3.0
 
+  object-assign@4.1.1: {}
+
   object-deep-merge@2.0.1: {}
 
   object-identity@0.2.3: {}
@@ -16464,6 +16569,12 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   proper-lockfile@4.1.2:
     dependencies:
       graceful-fs: 4.2.11
@@ -16588,10 +16699,10 @@ snapshots:
     dependencies:
       react: 19.2.8
       scheduler: 0.27.0
-    optional: true
 
-  react@19.2.8:
-    optional: true
+  react-is@16.13.1: {}
+
+  react@19.2.8: {}
 
   readable-stream@2.3.8:
     dependencies:
@@ -16964,8 +17075,7 @@ snapshots:
 
   sax@1.6.0: {}
 
-  scheduler@0.27.0:
-    optional: true
+  scheduler@0.27.0: {}
 
   scslre@0.3.0:
     dependencies:
@@ -17223,6 +17333,11 @@ snapshots:
   stable-hash-x@0.2.0: {}
 
   standard-as-callback@2.1.0: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
 
   statuses@2.0.2: {}
 

--- a/server/auth.config.ts
+++ b/server/auth.config.ts
@@ -1,13 +1,43 @@
 import { defineServerAuth } from '@nuxtjs/better-auth/config'
+import { checkout, polar, portal } from '@polar-sh/better-auth'
+import { Polar } from '@polar-sh/sdk'
 
 export default defineServerAuth(({ runtimeConfig }) => ({
   emailAndPassword: {
     enabled: true
+  },
+  account: {
+    accountLinking: {
+      enabled: true
+    }
   },
   socialProviders: {
     github: {
       clientId: runtimeConfig.githubClient?.id ?? '',
       clientSecret: runtimeConfig.githubClient?.secret ?? ''
     }
-  }
+  },
+  plugins: [
+    polar({
+      client: new Polar({
+        accessToken: runtimeConfig.polar?.accessToken ?? '',
+        server: 'sandbox'
+      }),
+      createCustomerOnSignUp: true,
+      use: [
+        checkout({
+          products: [{
+            productId: runtimeConfig.public?.polar?.productId ?? '',
+            slug: runtimeConfig.public?.polar?.productSlug ?? 'pro'
+          }],
+          successUrl: '/app?checkout=success',
+          authenticatedUsersOnly: true,
+          returnUrl: runtimeConfig.polar?.returnUrl ?? ''
+        }),
+        portal({
+          returnUrl: runtimeConfig.polar?.returnUrl ?? ''
+        })
+      ]
+    })
+  ]
 }))


### PR DESCRIPTION
Add Polar Sandbox billing to the authenticated app. A user can start checkout, see whether the Pro plan is active, and open the customer portal from the dashboard.

## Billing behavior

- Free users can start checkout for the configured `pro` product.
- Active subscribers see their plan status and can manage the subscription in Polar.
- Signing out clears the cached customer state, while failed checkout and portal requests show the returned error.
- Runtime config keeps the Polar token and return URL private. Product ID and slug remain available to the client.

This is the second PR in the auth stack and depends on #256. #261 uses the subscription state for todo limits and keeps signup working when Polar credentials are absent.
