### PR TITLE
fix(header): show docs navigation and search on mobile

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -24,7 +24,7 @@ const items = computed(() => [{
 </script>
 
 <template>
-  <UHeader :ui="{ right: 'gap-0.5' }">
+  <UHeader>
     <template #left>
       <NuxtLink to="/">
         <AppLogo class="w-auto h-6 shrink-0" />

--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -24,11 +24,12 @@ const items = computed(() => [{
 </script>
 
 <template>
-  <UHeader>
+  <UHeader :ui="{ right: 'gap-0.5' }">
     <template #left>
       <NuxtLink to="/">
         <AppLogo class="w-auto h-6 shrink-0" />
       </NuxtLink>
+
       <TemplateMenu />
     </template>
 
@@ -38,12 +39,9 @@ const items = computed(() => [{
     />
 
     <template #right>
-      <UContentSearchButton
-        v-if="isDocs"
-        class="lg:hidden"
-      />
-
       <UColorModeButton />
+
+      <UContentSearchButton class="lg:hidden" />
 
       <UButton
         icon="i-lucide-log-in"

--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -5,7 +5,7 @@ const route = useRoute()
 
 const navigation = inject<Ref<ContentNavigationItem[]>>('navigation')
 
-const isDocs = computed(() => route.path.startsWith('/docs'))
+const isDocs = computed(() => route.path === '/docs' || route.path.startsWith('/docs/'))
 
 const items = computed(() => [{
   label: 'Docs',

--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -1,10 +1,16 @@
 <script setup lang="ts">
+import type { ContentNavigationItem } from '@nuxt/content'
+
 const route = useRoute()
+
+const navigation = inject<Ref<ContentNavigationItem[]>>('navigation')
+
+const isDocs = computed(() => route.path.startsWith('/docs'))
 
 const items = computed(() => [{
   label: 'Docs',
   to: '/docs',
-  active: route.path.startsWith('/docs')
+  active: isDocs.value
 }, {
   label: 'Pricing',
   to: '/pricing'
@@ -32,6 +38,11 @@ const items = computed(() => [{
     />
 
     <template #right>
+      <UContentSearchButton
+        v-if="isDocs"
+        class="lg:hidden"
+      />
+
       <UColorModeButton />
 
       <UButton
@@ -65,6 +76,15 @@ const items = computed(() => [{
         orientation="vertical"
         class="-mx-2.5"
       />
+
+      <template v-if="isDocs">
+        <USeparator class="my-6" />
+
+        <UContentNavigation
+          :navigation="navigation"
+          highlight
+        />
+      </template>
 
       <USeparator class="my-6" />
 

--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -5,7 +5,19 @@ const route = useRoute()
 
 const navigation = inject<Ref<ContentNavigationItem[]>>('navigation')
 
+const { open: searchOpen } = useContentSearch()
+
+const open = ref(false)
+
 const isDocs = computed(() => route.path === '/docs' || route.path.startsWith('/docs/'))
+
+// Both modals portal to `body` with no z-index, so after a client-side layout
+// change the menu can end up painted over the search
+watch(searchOpen, (value) => {
+  if (value) {
+    open.value = false
+  }
+})
 
 const items = computed(() => [{
   label: 'Docs',
@@ -24,7 +36,7 @@ const items = computed(() => [{
 </script>
 
 <template>
-  <UHeader>
+  <UHeader v-model:open="open">
     <template #left>
       <NuxtLink to="/">
         <AppLogo class="w-auto h-6 shrink-0" />


### PR DESCRIPTION
The docs navigation and the search button only lived in `UPageAside`, whose root is `hidden lg:block`, so below `lg` there was no way to browse the docs or open the search besides the `meta_k` shortcut.

Moves both into the header on mobile, the same way the [docs template](https://github.com/nuxt-ui-templates/docs/blob/main/app/components/AppHeader.vue) already does it:

- collapsed `UContentSearchButton` in `#right` with `lg:hidden`
- `UContentNavigation` in `#body`, under the existing navigation menu

Both are gated on `/docs` routes so the marketing pages are untouched.

Closes #309

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a content search button to the mobile header.
  * Added mobile documentation navigation with highlighted current sections and a visual separator.
* **Improvements**
  * Improved documentation navigation highlighting for the main Docs page and related subpages.
  * Updated mobile header behavior so the menu closes when content search opens.
  * Refined header navigation for a clearer, more consistent experience on small screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->