### PR TITLE
fix(error): wrap in UApp instead of UToaster

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -29,24 +29,6 @@ const { data: files } = useLazyAsyncData('search', () => queryCollectionSearchSe
   server: false
 })
 
-const links = [{
-  label: 'Docs',
-  icon: 'i-lucide-book',
-  to: '/docs/getting-started'
-}, {
-  label: 'Pricing',
-  icon: 'i-lucide-credit-card',
-  to: '/pricing'
-}, {
-  label: 'Blog',
-  icon: 'i-lucide-pencil',
-  to: '/blog'
-}, {
-  label: 'Changelog',
-  icon: 'i-lucide-history',
-  to: '/changelog'
-}]
-
 provide('navigation', navigation)
 </script>
 
@@ -61,9 +43,8 @@ provide('navigation', navigation)
     <ClientOnly>
       <LazyUContentSearch
         :files="files"
-        shortcut="meta_k"
         :navigation="navigation"
-        :links="links"
+        :links="navLinks"
         :fuse="{ resultLimit: 42 }"
       />
     </ClientOnly>

--- a/app/error.vue
+++ b/app/error.vue
@@ -1,12 +1,9 @@
 <script setup lang="ts">
 import type { NuxtError } from '#app'
 
-defineProps({
-  error: {
-    type: Object as PropType<NuxtError>,
-    required: true
-  }
-})
+defineProps<{
+  error: NuxtError
+}>()
 
 useHead({
   htmlAttrs: {
@@ -26,23 +23,11 @@ const { data: files } = useLazyAsyncData('search', () => queryCollectionSearchSe
   server: false
 })
 
-const links = [{
-  label: 'Docs',
-  icon: 'i-lucide-book',
-  to: '/docs/getting-started'
-}, {
-  label: 'Pricing',
-  icon: 'i-lucide-credit-card',
-  to: '/pricing'
-}, {
-  label: 'Blog',
-  icon: 'i-lucide-pencil',
-  to: '/blog'
-}]
+provide('navigation', navigation)
 </script>
 
 <template>
-  <div>
+  <UApp>
     <AppHeader />
 
     <UMain>
@@ -58,13 +43,10 @@ const links = [{
     <ClientOnly>
       <LazyUContentSearch
         :files="files"
-        shortcut="meta_k"
         :navigation="navigation"
-        :links="links"
+        :links="navLinks"
         :fuse="{ resultLimit: 42 }"
       />
     </ClientOnly>
-
-    <UToaster />
-  </div>
+  </UApp>
 </template>

--- a/app/utils/links.ts
+++ b/app/utils/links.ts
@@ -1,0 +1,19 @@
+import type { NavigationMenuItem } from '@nuxt/ui'
+
+export const navLinks: NavigationMenuItem[] = [{
+  label: 'Docs',
+  icon: 'i-lucide-book',
+  to: '/docs/getting-started'
+}, {
+  label: 'Pricing',
+  icon: 'i-lucide-credit-card',
+  to: '/pricing'
+}, {
+  label: 'Blog',
+  icon: 'i-lucide-pencil',
+  to: '/blog'
+}, {
+  label: 'Changelog',
+  icon: 'i-lucide-history',
+  to: '/changelog'
+}]


### PR DESCRIPTION
`error.vue` replaces `app.vue` entirely on a fatal error, so it was rendering without `UApp` and only got the toaster. That means no tooltip, overlay or locale providers, which `UContentSearch` relies on.

Its `links` array had also drifted from the one in `app.vue` (missing `Changelog`), so both now read `navLinks` from `app/utils/links.ts` like the portfolio template does. `error.vue` provides `navigation` too, which it was missing.

Also drops the now-default `shortcut="meta_k"` on `UContentSearch` and switches `defineProps` to the type-based syntax.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent navigation links for Docs, Pricing, Blog, and Changelog.
  * Updated content search to use the shared navigation options.
  * Improved the error page with the same navigation experience as the rest of the application.
* **Bug Fixes**
  * Improved error-page handling and presentation for a more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->