### PR TITLE
fix: strip trailing slash from path before using as asyncData key

### DIFF
--- a/app/pages/blog/[slug].vue
+++ b/app/pages/blog/[slug].vue
@@ -2,15 +2,15 @@
 import { withoutTrailingSlash } from 'ufo'
 
 const route = useRoute()
-const path = computed(() => withoutTrailingSlash(route.path) || '/')
+const routePath = computed(() => withoutTrailingSlash(route.path))
 
-const { data: post } = await useAsyncData(path.value, () => queryCollection('posts').path(path.value).first())
+const { data: post } = await useAsyncData(routePath.value, () => queryCollection('posts').path(routePath.value).first())
 if (!post.value) {
   throw createError({ statusCode: 404, statusMessage: 'Post not found', fatal: true })
 }
 
-const { data: surround } = await useAsyncData(`${path.value}-surround`, () => {
-  return queryCollectionItemSurroundings('posts', path.value, {
+const { data: surround } = await useAsyncData(`${routePath.value}-surround`, () => {
+  return queryCollectionItemSurroundings('posts', routePath.value, {
     fields: ['description']
   })
 })

--- a/app/pages/blog/[slug].vue
+++ b/app/pages/blog/[slug].vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
-const route = useRoute()
+import { withoutTrailingSlash } from 'ufo'
 
-const { data: post } = await useAsyncData(route.path, () => queryCollection('posts').path(route.path).first())
+const route = useRoute()
+const path = computed(() => withoutTrailingSlash(route.path) || '/')
+
+const { data: post } = await useAsyncData(path.value, () => queryCollection('posts').path(path.value).first())
 if (!post.value) {
   throw createError({ statusCode: 404, statusMessage: 'Post not found', fatal: true })
 }
 
-const { data: surround } = await useAsyncData(`${route.path}-surround`, () => {
-  return queryCollectionItemSurroundings('posts', route.path, {
+const { data: surround } = await useAsyncData(`${path.value}-surround`, () => {
+  return queryCollectionItemSurroundings('posts', path.value, {
     fields: ['description']
   })
 })

--- a/app/pages/blog/index.vue
+++ b/app/pages/blog/index.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
+import { withoutTrailingSlash } from 'ufo'
+
 const route = useRoute()
+const path = computed(() => withoutTrailingSlash(route.path) || '/')
 
 const { data: page } = await useAsyncData('blog', () => queryCollection('blog').first())
-const { data: posts } = await useAsyncData(route.path, () => queryCollection('posts').all())
+const { data: posts } = await useAsyncData(path.value, () => queryCollection('posts').all())
 
 const title = page.value?.seo?.title || page.value?.title
 const description = page.value?.seo?.description || page.value?.description

--- a/app/pages/blog/index.vue
+++ b/app/pages/blog/index.vue
@@ -1,11 +1,6 @@
 <script setup lang="ts">
-import { withoutTrailingSlash } from 'ufo'
-
-const route = useRoute()
-const path = computed(() => withoutTrailingSlash(route.path) || '/')
-
 const { data: page } = await useAsyncData('blog', () => queryCollection('blog').first())
-const { data: posts } = await useAsyncData(path.value, () => queryCollection('posts').all())
+const { data: posts } = await useAsyncData('posts', () => queryCollection('posts').all())
 
 const title = page.value?.seo?.title || page.value?.title
 const description = page.value?.seo?.description || page.value?.description

--- a/app/pages/changelog/index.vue
+++ b/app/pages/changelog/index.vue
@@ -1,11 +1,6 @@
 <script setup lang="ts">
-import { withoutTrailingSlash } from 'ufo'
-
-const route = useRoute()
-const path = computed(() => withoutTrailingSlash(route.path) || '/')
-
 const { data: page } = await useAsyncData('changelog', () => queryCollection('changelog').first())
-const { data: versions } = await useAsyncData(path.value, () => queryCollection('versions').order('date', 'DESC').all())
+const { data: versions } = await useAsyncData('versions', () => queryCollection('versions').order('date', 'DESC').all())
 
 const title = page.value?.seo?.title || page.value?.title
 const description = page.value?.seo?.description || page.value?.description

--- a/app/pages/changelog/index.vue
+++ b/app/pages/changelog/index.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
+import { withoutTrailingSlash } from 'ufo'
+
 const route = useRoute()
+const path = computed(() => withoutTrailingSlash(route.path) || '/')
 
 const { data: page } = await useAsyncData('changelog', () => queryCollection('changelog').first())
-const { data: versions } = await useAsyncData(route.path, () => queryCollection('versions').order('date', 'DESC').all())
+const { data: versions } = await useAsyncData(path.value, () => queryCollection('versions').order('date', 'DESC').all())
 
 const title = page.value?.seo?.title || page.value?.title
 const description = page.value?.seo?.description || page.value?.description

--- a/app/pages/docs/[...slug].vue
+++ b/app/pages/docs/[...slug].vue
@@ -1,17 +1,20 @@
 <script setup lang="ts">
+import { withoutTrailingSlash } from 'ufo'
+
 definePageMeta({
   layout: 'docs'
 })
 
 const route = useRoute()
+const path = computed(() => withoutTrailingSlash(route.path) || '/')
 
-const { data: page } = await useAsyncData(route.path, () => queryCollection('docs').path(route.path).first())
+const { data: page } = await useAsyncData(path.value, () => queryCollection('docs').path(path.value).first())
 if (!page.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
 }
 
-const { data: surround } = await useAsyncData(`${route.path}-surround`, () => {
-  return queryCollectionItemSurroundings('docs', route.path, {
+const { data: surround } = await useAsyncData(`${path.value}-surround`, () => {
+  return queryCollectionItemSurroundings('docs', path.value, {
     fields: ['description']
   })
 })

--- a/app/pages/docs/[...slug].vue
+++ b/app/pages/docs/[...slug].vue
@@ -6,15 +6,15 @@ definePageMeta({
 })
 
 const route = useRoute()
-const path = computed(() => withoutTrailingSlash(route.path) || '/')
+const routePath = computed(() => withoutTrailingSlash(route.path))
 
-const { data: page } = await useAsyncData(path.value, () => queryCollection('docs').path(path.value).first())
+const { data: page } = await useAsyncData(routePath.value, () => queryCollection('docs').path(routePath.value).first())
 if (!page.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
 }
 
-const { data: surround } = await useAsyncData(`${path.value}-surround`, () => {
-  return queryCollectionItemSurroundings('docs', path.value, {
+const { data: surround } = await useAsyncData(`${routePath.value}-surround`, () => {
+  return queryCollectionItemSurroundings('docs', routePath.value, {
     fields: ['description']
   })
 })

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "nuxt": "^4.5.2",
     "nuxt-og-image": "^6.7.8",
     "tailwindcss": "^4.3.3",
+    "ufo": "^1.6.4",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
+      ufo:
+        specifier: ^1.6.4
+        version: 1.6.4
       zod:
         specifier: ^4.4.3
         version: 4.4.3


### PR DESCRIPTION
context: https://github.com/nuxt/nuxt/issues/36111
https://gitlab.com/eu-os/eu-os.gitlab.io/-/merge_requests/19
https://github.com/nuxt/content/pull/3838

on some hosts there may be trailing slashes, which means the route path should never be directly passed to `useAsyncData`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved content loading consistency across blog, documentation, and changelog pages.
  * Updated page data handling to reduce duplicate or stale results when navigating between content pages.
  * Improved reliability when loading individual articles, documentation pages, and related content.
  * Enhanced handling of page and version data across navigation and refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->