### PR TITLE
fix(AppHeader): add a visible focus ring to the logo link

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -38,7 +38,10 @@ const items = computed(() => [{
 <template>
   <UHeader v-model:open="open">
     <template #left>
-      <NuxtLink to="/">
+      <NuxtLink
+        to="/"
+        class="focus-visible:outline-3 outline-primary/25 rounded-md p-1 -ms-1"
+      >
         <AppLogo class="w-auto h-6 shrink-0" />
       </NuxtLink>
 


### PR DESCRIPTION
The logo link had no focus style of its own, so tabbing to it fell back to the browser default. Adds the same treatment already shipping in `docs` and `calendar`:

```
focus-visible:outline-3 outline-primary/25 rounded-md p-1 -ms-1
```

`p-1 -ms-1` gives the outline room to breathe without shifting the logo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility Improvements**
  - Added a visible focus outline to the header logo link for improved keyboard navigation.
  - Preserved the existing logo destination and content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->