### PR TITLE
fix(blog): replace broken picsum images with unsplash

### DIFF
--- a/content/3.blog/1.asian-cuisine.md
+++ b/content/3.blog/1.asian-cuisine.md
@@ -3,9 +3,9 @@ title: Exploring the Culinary Wonders of Asia
 description: "Embark on a tantalizing expedition through the diverse and
   enchanting flavors of Asia "
 image:
-  src: https://picsum.photos/id/490/640/360
+  src: https://images.unsplash.com/photo-1553621042-f6e147245754?auto=format&fit=crop&w=640&h=360&q=80
 authors:
-  - name: Alexia wong
+  - name: Alexia Wong
     to: https://twitter.com/benjamincanac
     avatar:
       src: https://i.pravatar.cc/128?u=0
@@ -22,15 +22,15 @@ Asia's culinary landscape is as diverse as its cultures. Chinese, Japanese, Thai
 
 ::pictures
   :::div
-  ![grappes](https://picsum.photos/id/75/400/400){.rounded-lg height="400" width="400"}
+  ![ramen](https://images.unsplash.com/photo-1569718212165-3a8278d5f624?auto=format&fit=crop&w=400&h=400&q=80){.rounded-lg height="400" width="400"}
   :::
 
   :::div
-  ![sakura](https://picsum.photos/id/82/400/400){.rounded-lg height="400" width="400"}
+  ![tea](https://images.unsplash.com/photo-1544787219-7f47ccb76574?auto=format&fit=crop&w=400&h=400&q=80){.rounded-lg height="400" width="400"}
   :::
 
   :::div
-  ![raspberry](https://picsum.photos/id/102/400/400){.rounded-lg height="400" width="400"}
+  ![curry](https://images.unsplash.com/photo-1455619452474-d2be8b1e70cd?auto=format&fit=crop&w=400&h=400&q=80){.rounded-lg height="400" width="400"}
   :::
 ::
 
@@ -42,27 +42,27 @@ Asian kitchens are a treasure trove of ingredients, each with its own story. Soy
 
 ::pictures
   :::div
-  ![wheat](https://picsum.photos/id/107/400/400){.rounded-lg height="400" width="400"}
+  ![poke bowl](https://images.unsplash.com/photo-1546069901-ba9599a7e63c?auto=format&fit=crop&w=400&h=400&q=80){.rounded-lg height="400" width="400"}
   :::
 
   :::div
-  ![tea](https://picsum.photos/id/225/400/400){.rounded-lg height="400" width="400"}
+  ![veggie bowl](https://images.unsplash.com/photo-1512621776951-a57141f2eefd?auto=format&fit=crop&w=400&h=400&q=80){.rounded-lg height="400" width="400"}
   :::
 
   :::div
-  ![nenuphar](https://picsum.photos/id/306/400/400){.rounded-lg height="400" width="400"}
+  ![noodles](https://images.unsplash.com/photo-1585032226651-759b368d7246?auto=format&fit=crop&w=400&h=400&q=80){.rounded-lg height="400" width="400"}
   :::
 
   :::div
-  ![flowers](https://picsum.photos/id/488/400/400){.rounded-lg height="400" width="400"}
+  ![curry and rice](https://images.unsplash.com/photo-1585937421612-70a008356fbe?auto=format&fit=crop&w=400&h=400&q=80){.rounded-lg height="400" width="400"}
   :::
 
   :::div
-  ![yuzu](https://picsum.photos/id/326/400/400){.rounded-lg height="400" width="400"}
+  ![salad](https://images.unsplash.com/photo-1540189549336-e6e99c3679fe?auto=format&fit=crop&w=400&h=400&q=80){.rounded-lg height="400" width="400"}
   :::
 
   :::div
-  ![strawberry](https://picsum.photos/id/493/400/400){.rounded-lg height="400" width="400"}
+  ![meat platter](https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&w=400&h=400&q=80){.rounded-lg height="400" width="400"}
   :::
 ::
 
@@ -70,7 +70,7 @@ Asian kitchens are a treasure trove of ingredients, each with its own story. Soy
 
 ### Salmon Avocado Sushi Rolls (Japan 🇯🇵)
 
-![fish](https://picsum.photos/id/615/1200/400){.rounded-lg height="400" width="1200"}
+![sushi](https://images.unsplash.com/photo-1579871494447-9811cf80d66c?auto=format&fit=crop&w=1200&h=400&q=80){.rounded-lg height="400" width="1200"}
 
 ::tabs
   :::div{icon="i-lucide-flame" label="Ingredients"}
@@ -110,7 +110,7 @@ Asian kitchens are a treasure trove of ingredients, each with its own story. Soy
 
 ### Nems/Cha Gio (Vietnam 🇻🇳)
 
-![kitchen boat](https://picsum.photos/id/686/1200/400){.rounded-lg height="400" width="1200"}
+![dumplings](https://images.unsplash.com/photo-1496116218417-1a781b1c416c?auto=format&fit=crop&w=1200&h=400&q=80){.rounded-lg height="400" width="1200"}
 
 ::tabs
   :::div
@@ -158,7 +158,7 @@ Asian kitchens are a treasure trove of ingredients, each with its own story. Soy
 
 ### Bibimbap (South Korean 🇰🇷)
 
-![bibimbap](https://picsum.photos/id/292/1200/400){.rounded-lg height="400" width="1200"}
+![bibimbap](https://images.unsplash.com/photo-1590301157890-4810ed352733?auto=format&fit=crop&w=1200&h=400&q=80){.rounded-lg height="400" width="1200"}
 
 ::tabs
   :::div
@@ -211,7 +211,7 @@ Asian kitchens are a treasure trove of ingredients, each with its own story. Soy
 
 ### Cheese Naan (India 🇮🇳)
 
-![Naan](https://picsum.photos/id/999/1200/400){.rounded-lg height="400" width="1200"}
+![naan](https://images.unsplash.com/photo-1631452180519-c014fe946bc7?auto=format&fit=crop&w=1200&h=400&q=80){.rounded-lg height="400" width="1200"}
 
 ::tabs
   :::div{icon="i-lucide-flame" label="Ingredients"}

--- a/content/3.blog/2.pyrenees.md
+++ b/content/3.blog/2.pyrenees.md
@@ -4,7 +4,7 @@ description: Embark on an unforgettable odyssey through the Pyrenees, where
   majestic peaks, pristine valleys, and rich cultural tapestries await in this
   immersive exploration.
 image:
-  src: https://picsum.photos/id/29/640/360
+  src: https://images.unsplash.com/photo-1464822759023-fed622ff2c3b?auto=format&fit=crop&w=640&h=360&q=80
 authors:
   - name: Nicolas Maillet
     to: https://twitter.com/benjamincanac
@@ -21,7 +21,7 @@ Embark on a breathtaking exploration of the Pyrenees, a mountain range that weav
 
 The Pyrenees are not merely a geographical boundary; they are a realm of awe-inspiring landscapes, ranging from lush green valleys to snow-capped peaks. The pristine wilderness is home to a diverse array of flora and fauna, creating a captivating tapestry of life that unfolds as you ascend.
 
-![mountains](https://picsum.photos/id/11/1000/600){.rounded-lg height="600" width="1000"}
+![mountains](https://images.unsplash.com/photo-1506905925346-21bda4d32df4?auto=format&fit=crop&w=1000&h=600&q=80){.rounded-lg height="600" width="1000"}
 
 ## Peaks and Valleys - Nature's Masterpiece
 
@@ -31,15 +31,15 @@ Explore the verdant meadows adorned with wildflowers, witness the dance of marmo
 
 ::pictures
   :::div
-  ![rocks](https://picsum.photos/id/15/400/400){.rounded-lg height="400" width="400"}
+  ![rocky peak](https://images.unsplash.com/photo-1458668383970-8ddd3927deed?auto=format&fit=crop&w=400&h=400&q=80){.rounded-lg height="400" width="400"}
   :::
 
   :::div
-  ![valley](https://picsum.photos/id/28/400/400){.rounded-lg height="400" width="400"}
+  ![valley](https://images.unsplash.com/photo-1472214103451-9374bd1c798e?auto=format&fit=crop&w=400&h=400&q=80){.rounded-lg height="400" width="400"}
   :::
 
   :::div
-  ![mountains](https://picsum.photos/id/29/400/400){.rounded-lg height="400" width="400"}
+  ![mountains](https://images.unsplash.com/photo-1519681393784-d120267933ba?auto=format&fit=crop&w=400&h=400&q=80){.rounded-lg height="400" width="400"}
   :::
 ::
 
@@ -51,16 +51,16 @@ Discover the legends that echo through the valleys, from tales of shepherds and 
 
 ::pictures{orientation="vertical"}
   :::div
-  ![valley](https://picsum.photos/id/118/1200/400){.rounded-lg.w-full height="400" width="1200"}
+  ![valley](https://images.unsplash.com/photo-1470252649378-9c29740c9fa8?auto=format&fit=crop&w=1200&h=400&q=80){.rounded-lg.w-full height="400" width="1200"}
   :::
 
   :::pictures
     ::::div
-    ![valley](https://picsum.photos/id/121/600/400){.rounded-lg height="400" width="600"}
+    ![valley](https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?auto=format&fit=crop&w=600&h=400&q=80){.rounded-lg height="400" width="600"}
     ::::
   
     ::::div
-    ![traveler](https://picsum.photos/id/177/600/400){.rounded-lg height="400" width="600"}
+    ![hikers](https://images.unsplash.com/photo-1551632811-561732d1e306?auto=format&fit=crop&w=600&h=400&q=80){.rounded-lg height="400" width="600"}
     ::::
   
     ::::div
@@ -76,29 +76,29 @@ The Pyrenees cater to all levels of outdoor enthusiasts, making it a haven for b
 
 ::pictures
   :::div
-  ![wood](https://picsum.photos/id/190/200/200){.rounded-lg height="200" width="200"}
+  ![wood](https://images.unsplash.com/photo-1511497584788-876760111969?auto=format&fit=crop&w=200&h=200&q=80){.rounded-lg height="200" width="200"}
   :::
 
   :::div
-  ![cow](https://picsum.photos/id/200/200/200){.rounded-lg height="200" width="200"}
+  ![cow](https://images.unsplash.com/photo-1546445317-29f4545e9d53?auto=format&fit=crop&w=200&h=200&q=80){.rounded-lg height="200" width="200"}
   :::
 
   :::div
-  ![meadow](https://picsum.photos/id/206/200/200){.rounded-lg height="200" width="200"}
+  ![forest](https://images.unsplash.com/photo-1441974231531-c6227db76b6e?auto=format&fit=crop&w=200&h=200&q=80){.rounded-lg height="200" width="200"}
   :::
 
   :::div
-  ![birds](https://picsum.photos/id/258/200/200){.rounded-lg height="200" width="200"}
+  ![bird](https://images.unsplash.com/photo-1444464666168-49d633b86797?auto=format&fit=crop&w=200&h=200&q=80){.rounded-lg height="200" width="200"}
   :::
 ::
 
 ::pictures
   :::div
-  ![road](https://picsum.photos/id/278/600/300){.rounded-lg.w-full height="300" width="600"}
+  ![road](https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?auto=format&fit=crop&w=600&h=300&q=80){.rounded-lg.w-full height="300" width="600"}
   :::
 
   :::div
-  ![hole in a rock](https://picsum.photos/id/343/600/300){.rounded-lg.w-full height="300" width="600"}
+  ![mountain lake](https://images.unsplash.com/photo-1476514525535-07fb3b4ae5f1?auto=format&fit=crop&w=600&h=300&q=80){.rounded-lg.w-full height="300" width="600"}
   :::
 ::
 
@@ -108,4 +108,4 @@ As we look to the future, conservation efforts and sustainable tourism initiativ
 
 In conclusion, 'Discovering the Majestic Peaks: A Journey Through the Pyrenees' invites you to witness the grandeur of a mountain range that transcends geographical boundaries, offering a symphony of nature, culture, and adventure in every chapter.
 
-![mountains](https://picsum.photos/id/368/600/300){.rounded-lg.w-full height="300" width="600"}
+![mountains](https://images.unsplash.com/photo-1454496522488-7a8e488e8606?auto=format&fit=crop&w=600&h=300&q=80){.rounded-lg.w-full height="300" width="600"}

--- a/content/3.blog/3.james-webb.md
+++ b/content/3.blog/3.james-webb.md
@@ -2,7 +2,7 @@
 title: Unveiling the Marvel
 description: The Journey to Create the James Webb Space Telescope
 image:
-  src: https://picsum.photos/id/903/640/360
+  src: https://images.unsplash.com/photo-1462331940025-496dfbfc7564?auto=format&fit=crop&w=640&h=360&q=80
 authors:
   - name: Josh Bayers
     to: https://twitter.com/benjamincanac
@@ -10,7 +10,7 @@ authors:
       src: https://i.pravatar.cc/128?u=2
 date: 2020-12-12
 badge:
-  label: Science, Astronomie, History
+  label: Science, Astronomy, History
 ---
 
 ## Building the Vision
@@ -21,7 +21,7 @@ badge:
 In the bustling halls of NASA's engineering facilities, a team of brilliant minds gathered around blueprints and prototypes. They envisioned a telescope unlike any other, one that would revolutionize our understanding of the cosmos. Led by Dr. Catherine Nguyen, they meticulously crafted the design for what would become the James Webb Space Telescope (JWST). With its massive primary mirror and cutting-edge infrared technology, the JWST promised to unveil the deepest mysteries of the universe.
 
 #image
-![sky](https://picsum.photos/id/120/400/400){.rounded-lg height="400" width="400"}
+![starry sky](https://images.unsplash.com/photo-1419242902214-272b3f66ee7a?auto=format&fit=crop&w=400&h=400&q=80){.rounded-lg height="400" width="400"}
 ::
 
 ::picture-and-text
@@ -33,7 +33,7 @@ reverse: true
 However, the path to launch was fraught with challenges. Engineers faced immense pressure to ensure the JWST's success, navigating technical hurdles and budget constraints. Delays mounted as unforeseen complications arose, testing the team's resolve. Yet, fueled by their passion for exploration, they pressed onward, refining each component with unwavering determination. Through perseverance and ingenuity, they transformed the JWST from a concept into a marvel of modern engineering.
 
 #image
-![mountain](https://picsum.photos/id/235/400/400){.rounded-lg height="400" width="400"}
+![earth at night](https://images.unsplash.com/photo-1451187580459-43490279c0fa?auto=format&fit=crop&w=400&h=400&q=80){.rounded-lg height="400" width="400"}
 ::
 
 ## Embarking into the Unknown
@@ -44,7 +44,7 @@ However, the path to launch was fraught with challenges. Engineers faced immense
 On a crisp morning at the Guiana Space Centre in French Guiana, anticipation hung in the air as the JWST stood tall atop its Ariane 5 rocket. Millions around the world held their breath as countdown reached its final moments. Then, with a thunderous roar, the rocket ignited, propelling the telescope into the vast expanse of space. As it soared higher and higher, the JWST represented humanity's boundless curiosity and relentless pursuit of knowledge.
 
 #image
-![rocket](https://picsum.photos/id/137/400/400){.rounded-lg height="400" width="400"}
+![rocket](https://images.unsplash.com/photo-1517976487492-5750f3195933?auto=format&fit=crop&w=400&h=400&q=80){.rounded-lg height="400" width="400"}
 ::
 
 ::picture-and-text
@@ -56,7 +56,7 @@ reverse: true
 Months later, nestled in its orbit around the Earth, the JWST embarked on its monumental mission. With its golden mirrors unfurled like petals, it peered into the depths of the cosmos, capturing breathtaking images of distant galaxies and nebulae. Each observation unveiled new wonders, shedding light on the origins of stars, planets, and life itself. From the icy realms of the outer solar system to the fiery cores of distant exoplanets, the JWST's gaze transcended the limits of human imagination.
 
 #image
-![universe](https://picsum.photos/id/974/400/400){.rounded-lg height="400" width="400"}
+![satellite](https://images.unsplash.com/photo-1446776811953-b23d57bd21aa?auto=format&fit=crop&w=400&h=400&q=80){.rounded-lg height="400" width="400"}
 ::
 
 ## Legacy of Discovery
@@ -67,7 +67,7 @@ Months later, nestled in its orbit around the Earth, the JWST embarked on its mo
 As the years passed, the JWST's legacy continued to grow, inspiring generations to dream of the stars. Its groundbreaking discoveries sparked scientific revolutions and expanded humanity's collective understanding of the universe. From classrooms to observatories, its images adorned the walls, igniting the spark of curiosity in the minds of countless individuals. The JWST served as a beacon of hope, reminding us of our capacity to explore, discover, and unite in pursuit of a shared destiny among the stars.
 
 #image
-![woman](https://picsum.photos/id/550/400/400){.rounded-lg height="400" width="400"}
+![stargazing](https://images.unsplash.com/photo-1444703686981-a3abbc4d4fe3?auto=format&fit=crop&w=400&h=400&q=80){.rounded-lg height="400" width="400"}
 ::
 
 ::picture-and-text
@@ -79,5 +79,5 @@ reverse: true
 Though the JWST's mission eventually came to a close, its impact endured far beyond the boundaries of space and time. Its data continued to fuel scientific inquiry for decades to come, unlocking new realms of knowledge and shaping the course of human history. And as future telescopes followed in its wake, each building upon its pioneering legacy, the spirit of exploration embodied by the James Webb Space Telescope lived on, guiding humanity toward ever greater heights of discovery and understanding.
 
 #image
-![sunset](https://picsum.photos/id/967/400/400){.rounded-lg height="400" width="400"}
+![astronaut](https://images.unsplash.com/photo-1454789548928-9efd52dc4031?auto=format&fit=crop&w=400&h=400&q=80){.rounded-lg height="400" width="400"}
 ::

--- a/content/3.blog/4.meditation.md
+++ b/content/3.blog/4.meditation.md
@@ -2,7 +2,7 @@
 title: The Benefits of Meditation
 description: The Benefits of Meditation and Mindfulness Practices on Mental Health
 image:
-  src: https://picsum.photos/id/691/640/360
+  src: https://images.unsplash.com/photo-1506126613408-eca07ce68773?auto=format&fit=crop&w=640&h=360&q=80
 authors:
   - name: Rebecca Millers
     to: https://twitter.com/benjamincanac
@@ -13,7 +13,7 @@ badge:
   label: Health
 ---
 
-![grass in wood](https://picsum.photos/id/55/1200/600){.rounded-lg height="600" width="1200"}
+![forest](https://images.unsplash.com/photo-1447752875215-b2761acb3c5d?auto=format&fit=crop&w=1200&h=600&q=80){.rounded-lg height="600" width="1200"}
 
 ## 🧘🏻 Introduction
 
@@ -27,11 +27,11 @@ One of the most well-documented benefits of meditation and mindfulness is their 
 
 ::pictures
   :::div
-  ![flowers](https://picsum.photos/id/106/600/200){.rounded-lg height="200" width="600"}
+  ![flowers](https://images.unsplash.com/photo-1490750967868-88aa4486c946?auto=format&fit=crop&w=600&h=200&q=80){.rounded-lg height="200" width="600"}
   :::
 
   :::div
-  ![sakura](https://picsum.photos/id/82/600/200){.rounded-lg height="200" width="600"}
+  ![sakura](https://images.unsplash.com/photo-1522383225653-ed111181a951?auto=format&fit=crop&w=600&h=200&q=80){.rounded-lg height="200" width="600"}
   :::
 ::
 
@@ -45,7 +45,7 @@ Another significant benefit of meditation and mindfulness is their positive impa
 
 ## 💪🏻 Building Resilience and Coping Skills
 
-![water](https://picsum.photos/id/126/1200/300){.rounded-lg height="300" width="1200"}
+![water](https://images.unsplash.com/photo-1505142468610-359e7d316be0?auto=format&fit=crop&w=1200&h=300&q=80){.rounded-lg height="300" width="1200"}
 
 Life is filled with ups and downs, challenges, and setbacks. Meditation and mindfulness provide valuable tools for building resilience and coping with adversity. By cultivating a sense of inner strength and equanimity, these practices help individuals navigate difficult situations with greater ease and grace. They teach us to respond to stressors with mindfulness and compassion, rather than reacting impulsively out of fear or frustration.
 
@@ -57,4 +57,4 @@ Beyond benefiting individual mental health, meditation and mindfulness also prom
 
 In conclusion, the benefits of meditation and mindfulness on mental health are undeniable. From reducing stress and anxiety to improving focus, emotional well-being, and resilience, these ancient practices offer a holistic approach to mental wellness in an increasingly hectic world. By incorporating meditation and mindfulness into our daily lives, we can nurture a sense of inner peace, balance, and contentment that radiates outward, enriching not only our own lives but the lives of those around us as well.
 
-![nenuphar](https://picsum.photos/id/306/1200/600){.rounded-lg height="600" width="1200"}
+![water lily](https://images.unsplash.com/photo-1474557157379-8aa74a6ef541?auto=format&fit=crop&w=1200&h=600&q=80){.rounded-lg height="600" width="1200"}

--- a/content/3.blog/5.animals.md
+++ b/content/3.blog/5.animals.md
@@ -2,7 +2,7 @@
 title: The 10 Most Dangerous Creatures on Earth
 description: From Predators to the Ultimate Threat
 image:
-  src: https://picsum.photos/id/219/640/360
+  src: https://images.unsplash.com/photo-1474511320723-9a56873867b5?auto=format&fit=crop&w=640&h=360&q=80
 authors:
   - name: Emilio Manuel
     to: https://twitter.com/benjamincanac
@@ -21,10 +21,10 @@ The natural world is teeming with creatures of all shapes and sizes, each with i
 ---
 card: true
 ---
-**Tigers** are dangerous to humans because of their immense strength, powerful jaws, and sharp claws, capable of causing fatal injuries. Additionally, tigers are territorial and can become highly aggressive if they feel threatened or if their territory is encroached upon.
+**Lions** are dangerous to humans because of their immense strength, powerful jaws, and sharp claws, capable of causing fatal injuries. Additionally, lions are territorial and can become highly aggressive if they feel threatened or if their territory is encroached upon.
 
 #image
-![Lion](https://picsum.photos/id/1074/800/400){.rounded-lg height="400" width="800"}
+![lion](https://images.unsplash.com/photo-1546182990-dffeafbe841d?auto=format&fit=crop&w=800&h=400&q=80){.rounded-lg height="400" width="800"}
 ::
 
 ## Monkeys
@@ -36,7 +36,7 @@ card: true
 **Monkeys** are dangerous to humans due to their sharp teeth and strong jaws, which can inflict serious bites, and their potential to carry and transmit diseases such as rabies. Additionally, monkeys can become aggressive if they feel threatened or if they are protecting their young.
 
 #image
-![monkey](https://picsum.photos/id/783/800/400){.rounded-lg height="400" width="800"}
+![monkey](https://images.unsplash.com/photo-1540573133985-87b6da6d54a9?auto=format&fit=crop&w=800&h=400&q=80){.rounded-lg height="400" width="800"}
 ::
 
 ## Wolf
@@ -48,7 +48,7 @@ card: true
 **Wolves** are dangerous to humans due to their pack hunting behavior, which can overwhelm and outnumber a person, and their strong jaws capable of inflicting serious injuries. Additionally, wolves may become aggressive if they feel their territory or pack is threatened.
 
 #image
-![wolf](https://picsum.photos/id/582/800/400){.rounded-lg height="400" width="800"}
+![wolf](https://images.unsplash.com/photo-1504715329877-f69f5258f4e8?auto=format&fit=crop&w=800&h=400&q=80){.rounded-lg height="400" width="800"}
 ::
 
 ## Bears
@@ -60,7 +60,7 @@ card: true
 **Bears** are dangerous to humans due to their immense strength and powerful claws, which can cause severe injuries or death. Additionally, bears are highly protective of their young and can become aggressive if they feel threatened or surprised.
 
 #image
-![Bears](https://picsum.photos/id/1020/800/400){.rounded-lg height="400" width="800"}
+![bear](https://images.unsplash.com/photo-1530595467537-0b5996c41f2d?auto=format&fit=crop&w=800&h=400&q=80){.rounded-lg height="400" width="800"}
 ::
 
 ## Great White Shark
@@ -72,7 +72,7 @@ card: true
 As the apex predator of the ocean, the **great white shark** strikes fear into the hearts of beachgoers and surfers around the world. With its razor-sharp teeth and lightning-fast attacks, this formidable predator is the stuff of nightmares for many.
 
 #image
-![sea](https://picsum.photos/id/124/800/400){.rounded-lg height="400" width="800"}
+![shark](https://images.unsplash.com/photo-1560275619-4662e36fa65c?auto=format&fit=crop&w=800&h=400&q=80){.rounded-lg height="400" width="800"}
 ::
 
 ## Mosquito
@@ -84,7 +84,7 @@ card: true
 While tiny in size, the **mosquito** is responsible for more human deaths than any other creature on Earth. As carriers of deadly diseases such as malaria, dengue fever, and Zika virus, these blood-sucking insects pose a significant threat to public health worldwide.
 
 #image
-![human](https://picsum.photos/id/996/800/400){.rounded-lg height="400" width="800"}
+![mosquito](https://images.unsplash.com/photo-1707943768453-7850f916ebde?auto=format&fit=crop&w=800&h=400&q=80){.rounded-lg height="400" width="800"}
 ::
 
 ## Golden Poison Frog
@@ -96,7 +96,7 @@ card: true
 The **Golden Poison Frog**, native to the rainforests of Colombia, is considered one of the most toxic amphibians on the planet. Despite its vibrant golden coloration, this frog secretes potent neurotoxins through its skin, which can cause severe reactions or even death if ingested or handled improperly. Its toxicity serves as a defense mechanism against predators, making it one of the most dangerous frogs in the world.
 
 #image
-![marsh](https://picsum.photos/id/128/800/400){.rounded-lg height="400" width="800"}
+![golden poison frog](https://images.unsplash.com/photo-1465502122287-9eab969fac20?auto=format&fit=crop&w=800&h=400&q=80){.rounded-lg height="400" width="800"}
 ::
 
 ## King Cobra
@@ -108,7 +108,7 @@ card: true
 As the largest venomous snake in the world, the **king cobra** commands respect wherever it is found. With its deadly venom and impressive size, this iconic serpent is a top predator in its habitat and a formidable adversary for any would-be threat.
 
 #image
-![desert](https://picsum.photos/id/196/800/400){.rounded-lg height="400" width="800"}
+![king cobra](https://images.unsplash.com/photo-1531386151447-fd76ad50012f?auto=format&fit=crop&w=800&h=400&q=80){.rounded-lg height="400" width="800"}
 ::
 
 ## Jaguars
@@ -120,7 +120,7 @@ card: true
 **Jaguars** are dangerous to humans due to their powerful bite, capable of crushing skulls, and their aggressive territorial defense, especially if they feel threatened. Their stealth, agility, and adaptability to various environments further increase the risk of unexpected encounters.
 
 #image
-![Jaguars](https://picsum.photos/id/219/800/400){.rounded-lg height="400" width="800"}
+![jaguar](https://images.unsplash.com/photo-1571070201382-a45dd17e17e2?auto=format&fit=crop&w=800&h=400&q=80){.rounded-lg height="400" width="800"}
 ::
 
 ## Humans
@@ -134,5 +134,5 @@ While not traditionally viewed as a "wild" creature, **humans** have proven to b
 In conclusion, while the natural world is filled with creatures of all shapes and sizes, it is ultimately humans who pose the greatest threat to our own survival and the delicate balance of life on Earth. As stewards of our planet, it is imperative that we respect and protect the diverse array of species that call it home, lest we face the consequences of our own actions.
 
 #image
-![humans](https://picsum.photos/id/978/800/800){.rounded-lg height="800" width="800"}
+![humans](https://images.unsplash.com/photo-1529156069898-49953e39b3ac?auto=format&fit=crop&w=800&h=800&q=80){.rounded-lg height="800" width="800"}
 ::

--- a/content/3.blog/6.cryptocurrencies.md
+++ b/content/3.blog/6.cryptocurrencies.md
@@ -2,9 +2,9 @@
 title: The Rise of Cryptocurrencies
 description: Transforming Finance and Economy
 image:
-  src: https://picsum.photos/id/1048/640/360
+  src: https://images.unsplash.com/photo-1518546305927-5a555bb7020d?auto=format&fit=crop&w=640&h=360&q=80
 authors:
-  - name: Emily pasek
+  - name: Emily Pasek
     to: https://twitter.com/benjamincanac
     avatar:
       src: https://i.pravatar.cc/128?u=5
@@ -15,7 +15,7 @@ badge:
 
 In recent years, cryptocurrencies have emerged as a disruptive force in the world of finance and economics. Born out of the decentralized ethos of blockchain technology, cryptocurrencies have challenged traditional financial systems, offering new avenues for investment, transactions, and economic empowerment. This article explores the impact of cryptocurrencies on the economy and finance, examining their evolution, opportunities, and challenges.
 
-![computer](https://picsum.photos/id/3/1000/600){.rounded-lg height="600" width="1000"}
+![circuit board](https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=1000&h=600&q=80){.rounded-lg height="600" width="1000"}
 
 ## The Evolution of Cryptocurrencies
 
@@ -81,7 +81,7 @@ These cryptocurrencies are among the most recognized and widely used in the cryp
   icon: i-simple-icons-litecoin
   target: _blank
   title: Litecoin (LTC)
-  to: https://litecoin.com//
+  to: https://litecoin.com/
   ---
   Known for faster transaction times and a more decentralized approach compared to Bitcoin.
   :::


### PR DESCRIPTION
picsum.photos is down (every route times out or returns 503), so all blog images were broken. This replaces the 47 picsum URLs with Unsplash images matching each post's topic, the same host the changelog entries already use. Every new URL returns 200 and I checked each image visually, alt texts updated to match.

Also fixes a few content issues in the same files: the Lion section described tigers, "Astronomie" → "Astronomy", author name capitalization (Alexia Wong, Emily Pasek) and a double trailing slash in the litecoin.com link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Content Updates**
  - Replaced placeholder blog imagery with themed Unsplash photos across six articles.
  - Improved image descriptions to better match the displayed subjects.
  - Corrected author capitalization and the “Astronomie” badge label.
  - Corrected the dangerous animals section heading and related animal labels.
  - Updated cryptocurrency article imagery and fixed the Litecoin link formatting.
- **Bug Fixes**
  - Corrected inaccurate image alt text and article labels for clearer, more accurate content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->