### PR TITLE
fix: replace dead promotional video with youtube embed

### DIFF
--- a/app/components/PromotionalVideo.vue
+++ b/app/components/PromotionalVideo.vue
@@ -4,26 +4,15 @@
       variant="subtle"
       class="rounded-2xl"
     >
-      <video
-        class="rounded-xl"
-        data-v-baf90ddd=""
-        preload="none"
-        poster="https://res.cloudinary.com/nuxt/video/upload/so_3.3/v1708511800/ui-pro/video-nuxt-ui-pro_kwfbdh.jpg"
-        :controls="true"
-      ><source
-        data-v-baf90ddd=""
-        src="https://res.cloudinary.com/nuxt/video/upload/v1708511800/ui-pro/video-nuxt-ui-pro_kwfbdh.webm"
-        type="video/webm"
-      ><source
-        data-v-baf90ddd=""
-        src="https://res.cloudinary.com/nuxt/video/upload/v1708511800/ui-pro/video-nuxt-ui-pro_kwfbdh.mp4"
-        type="video/mp4"
-      ><source
-        data-v-baf90ddd=""
-        src="https://res.cloudinary.com/nuxt/video/upload/v1708511800/ui-pro/video-nuxt-ui-pro_kwfbdh.ogg"
-        type="video/ogg"
-      >
-      </video>
+      <iframe
+        class="rounded-xl aspect-video w-full"
+        src="https://www.youtube-nocookie.com/embed/_eQxomah-nA"
+        title="My New Favorite UI Library"
+        loading="lazy"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        referrerpolicy="strict-origin-when-cross-origin"
+        allowfullscreen
+      />
     </UPageCard>
   </div>
 </template>


### PR DESCRIPTION
The hero video on the home page pointed at Cloudinary assets that were deleted (all four URLs 404, same on the live template). Since there's no replacement asset hosted anywhere, this swaps the `<video>` for the YouTube embed already used in the docs (`youtube-nocookie.com`), lazy loaded, inside the same `UPageCard`. Also drops the stray `data-v-baf90ddd` attributes that were left over from a copy paste.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the promotional video to use a YouTube embed.
  * Improved video presentation with a responsive widescreen layout, rounded corners, and lazy loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->