### PR TITLE
chore: improve pricing copy and update renamed icons

### DIFF
--- a/content/0.index.yml
+++ b/content/0.index.yml
@@ -33,7 +33,7 @@ sections:
         icon: i-lucide-shield
       - name: TypeScript First
         description: Full TypeScript support with auto-completion, type safety, and IntelliSense for every component and composable.
-        icon: i-lucide-code-2
+        icon: i-lucide-code-xml
   - title: Built for Modern SaaS
     description: Everything you need to launch and scale your SaaS. From beautiful marketing pages to complex dashboards, ship faster with production-ready patterns.
     orientation: horizontal
@@ -66,7 +66,7 @@ features:
       icon: i-lucide-search
     - title: Production Ready
       description: Error handling, loading states, form validation, and security best practices built into every component.
-      icon: i-lucide-check-circle
+      icon: i-lucide-circle-check
     - title: Infinitely Customizable
       description: Override any style with the ui prop, customize globally with AppConfig, or use Tailwind classes directly.
       icon: i-lucide-settings

--- a/content/2.pricing.yml
+++ b/content/2.pricing.yml
@@ -1,5 +1,5 @@
 title: A plan for every need
-description: Our plans are designed to meet the requirements of both beginners and players. Get the right plan that suits you.
+description: Our plans are designed to meet the requirements of both individuals and teams. Get the right plan that suits you.
 seo:
   title: Pricing
   description: Choose the plan that's right for you.
@@ -59,24 +59,24 @@ plans:
 logos:
   title: Trusted by the world's best
   icons:
-    - i-simple-icons-amazonaws
+    - i-simple-icons-amazonwebservices
     - i-simple-icons-heroku
     - i-simple-icons-netlify
     - i-simple-icons-vercel
     - i-simple-icons-cloudflare
 faq:
   title: Frequently asked questions
-  description: Culpa consectetur dolor pariatur commodo aliqua amet tempor nisi enim deserunt elit cillum.
+  description: Everything you need to know about our plans and billing. Can't find the answer you're looking for? Reach out to our support team.
   items:
     - label: Is this a secure service?
-      content: Qui sunt nostrud aliquip reprehenderit enim proident veniam magna aliquip velit occaecat eiusmod nisi deserunt sunt.
+      content: Yes. All data is encrypted in transit and at rest, and every plan includes SSL certificates. We follow industry best practices to keep your data safe.
     - label: How can I cancel my subscription?
-      content: Consectetur irure Lorem nostrud adipisicing aliqua mollit Lorem sit officia magna eiusmod cupidatat.
+      content: You can cancel anytime from your account settings. Your plan stays active until the end of the current billing period and you won't be charged again.
     - label: How does the free trial work?
-      content: Quis officia commodo magna eu qui aliquip duis.
+      content: Every plan comes with a 14-day free trial, no credit card required. Upgrade whenever you're ready and keep everything you've set up.
     - label: Can I switch plans later?
-      content: Dolore irure ullamco dolore eu occaecat magna eiusmod dolor aliqua culpa labore.
+      content: Yes, you can upgrade or downgrade at any time. Changes take effect immediately and we prorate the difference on your next invoice.
     - label: Do you offer refunds?
-      content: Duis mollit nostrud voluptate mollit Lorem dolore commodo veniam incididunt eiusmod.
+      content: If you're not satisfied within the first 30 days, contact us and we'll issue a full refund, no questions asked.
     - label: Do you offer support?
-      content: Aliqua sit nisi consequat pariatur Lorem minim irure qui.
+      content: All plans include email support. The Standard and Premium plans also come with priority support and faster response times.


### PR DESCRIPTION
Replaces the lorem ipsum FAQ on the pricing page with real copy and fixes the page description ("beginners and players" → "individuals and teams").

Also updates icon names to their canonical ids: `amazonaws` was removed from simple-icons and `code-2`/`check-circle` were renamed in lucide. The old names still resolve as iconify aliases today but that can break on a future icon set update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Content Updates**
  - Updated feature icons for improved visual clarity.
  - Refined pricing page language to address individuals and teams.
  - Replaced placeholder FAQ text with clear answers covering security, cancellations, trials, plan changes, refunds, and support.
- **Documentation**
  - Improved pricing and FAQ descriptions to make plan information easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->